### PR TITLE
Replace google/uuid with crypto/rand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/cheggaaa/pb/v3 v3.0.8
-	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.7.0
 	github.com/thepatrik/strcolor v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=

--- a/pkg/testunit/testunit.go
+++ b/pkg/testunit/testunit.go
@@ -2,8 +2,8 @@ package testunit
 
 import (
 	"context"
-
-	"github.com/google/uuid"
+	"crypto/rand"
+	"fmt"
 )
 
 // TestUnit type
@@ -75,7 +75,7 @@ type TestAssembly struct {
 // New constructs a new test
 func New(options ...Option) *TestAssembly {
 	cfg := &Config{
-		ID:      uuid.New().String(),
+		ID:      randomID(),
 		Enabled: func() (bool, string) { return true, "" },
 		Prepare: func(context.Context) ([]interface{}, error) { return nil, nil },
 		Test:    func(context.Context, []interface{}) ([]interface{}, error) { return nil, nil },
@@ -111,4 +111,10 @@ func (test *TestAssembly) Test(ctx context.Context, args []interface{}) ([]inter
 // Cleanup runs after Test(context.Context, []interface{}) error
 func (test *TestAssembly) Cleanup(ctx context.Context, args []interface{}) error {
 	return test.cfg.Cleanup(ctx, args)
+}
+
+func randomID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }


### PR DESCRIPTION
Generate random IDs using the standard library instead of an external UUID package.