### PR TITLE
Replace strcolor with ANSI escape codes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.15
 require (
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/stretchr/testify v1.7.0
-	github.com/thepatrik/strcolor v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/thepatrik/strcolor v1.0.3 h1:lFuGZwKJn1CwbXYagm8jVKmLh9FPCrd3T7FGSm4jEjc=
-github.com/thepatrik/strcolor v1.0.3/go.mod h1:I519L4XnoZZmMJauibTGgy7XODjJ1st3IusYns7MOrg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=

--- a/pkg/handlers/logger.go
+++ b/pkg/handlers/logger.go
@@ -10,8 +10,15 @@ import (
 
 	"github.com/spider-pigs/spidomtr"
 	"github.com/spider-pigs/spidomtr/pkg/testunit"
-	"github.com/thepatrik/strcolor"
 )
+
+func colorize(color, s string) string {
+	return "\033[" + color + "m" + s + "\033[0m"
+}
+
+func yellow(s string) string { return colorize("33", s) }
+func red(s string) string    { return colorize("31", s) }
+func green(s string) string  { return colorize("32", s) }
 
 const (
 	checkMark = "√"
@@ -45,31 +52,31 @@ func (logger *TestLogger) TestDone(res spidomtr.TestResult) {
 	switch res.Outcome {
 	case testunit.Skip:
 		fmt.Fprintf(logger.Buffer, "%s %s: %s\n", skipMark, res.ID, res.Comment)
-		logger.Log.Printf("%s %s: %s\n", strcolor.Yellow(skipMark), res.ID, res.Comment)
+		logger.Log.Printf("%s %s: %s\n", yellow(skipMark), res.ID, res.Comment)
 	case testunit.Fail:
 		fmt.Fprintf(logger.Buffer, "%s %s: %s\n", crossMark, res.ID, res.Error)
-		logger.Log.Printf("%s %s: %s\n", strcolor.Red(crossMark), res.ID, res.Error)
+		logger.Log.Printf("%s %s: %s\n", red(crossMark), res.ID, res.Error)
 	case testunit.Pass:
 		fmt.Fprintf(logger.Buffer, "%s %s: %s\n", checkMark, res.ID, res.Duration)
-		logger.Log.Printf("%s %s: %s\n", strcolor.Green(checkMark), res.ID, res.Duration)
+		logger.Log.Printf("%s %s: %s\n", green(checkMark), res.ID, res.Duration)
 	}
 }
 
 // RunnerDone is called when the runner has run all tests.
 func (logger *TestLogger) RunnerDone(res spidomtr.Result) {
-	mark := func() strcolor.StrColor {
+	mark := func() string {
 		switch {
 		case res.Stats.Errors > 0:
-			return strcolor.Red(crossMark)
+			return red(crossMark)
 		case res.Stats.Skips > 0:
-			return strcolor.Yellow(skipMark)
+			return yellow(skipMark)
 		}
-		return strcolor.Green(checkMark)
+		return green(checkMark)
 	}()
 
 	str := fmt.Sprintf("%d/%d passed, %d failed, %d skipped, took %s, avg %s/test", res.Stats.Passed, res.Stats.Count, res.Stats.Errors, res.Stats.Skips, res.Stats.Duration, res.Stats.Average)
 	divider := strings.Repeat("-", utf8.RuneCountInString(str)+2)
 
-	fmt.Fprintf(logger.Buffer, "%s\n%s %s\n%s\n", divider, mark.Val, str, divider)
+	fmt.Fprintf(logger.Buffer, "%s\n%s %s\n%s\n", divider, mark, str, divider)
 	logger.Log.Printf("%s\n%s %s\n%s\n", divider, mark, str, divider)
 }


### PR DESCRIPTION
Use inline color helpers instead of the external strcolor package for terminal output.