### PR TITLE
Fix terminal output when using multiple handlers

### DIFF
--- a/pkg/handlers/logger.go
+++ b/pkg/handlers/logger.go
@@ -44,7 +44,6 @@ func (logger *TestLogger) RunnerStarted(id, description string, count int) {
 	logger.Buffer = &bytes.Buffer{}
 
 	fmt.Fprintf(logger.Buffer, "Running %s: %s...\n", id, description)
-	logger.Log.Printf("Running %s: %s\n", id, description)
 }
 
 // TestDone is called when a test has been completed.
@@ -52,13 +51,10 @@ func (logger *TestLogger) TestDone(res spidomtr.TestResult) {
 	switch res.Outcome {
 	case testunit.Skip:
 		fmt.Fprintf(logger.Buffer, "%s %s: %s\n", skipMark, res.ID, res.Comment)
-		logger.Log.Printf("%s %s: %s\n", yellow(skipMark), res.ID, res.Comment)
 	case testunit.Fail:
 		fmt.Fprintf(logger.Buffer, "%s %s: %s\n", crossMark, res.ID, res.Error)
-		logger.Log.Printf("%s %s: %s\n", red(crossMark), res.ID, res.Error)
 	case testunit.Pass:
 		fmt.Fprintf(logger.Buffer, "%s %s: %s\n", checkMark, res.ID, res.Duration)
-		logger.Log.Printf("%s %s: %s\n", green(checkMark), res.ID, res.Duration)
 	}
 }
 
@@ -78,5 +74,6 @@ func (logger *TestLogger) RunnerDone(res spidomtr.Result) {
 	divider := strings.Repeat("-", utf8.RuneCountInString(str)+2)
 
 	fmt.Fprintf(logger.Buffer, "%s\n%s %s\n%s\n", divider, mark, str, divider)
+	logger.Log.Print(logger.Buffer.String())
 	logger.Log.Printf("%s\n%s %s\n%s\n", divider, mark, str, divider)
 }

--- a/pkg/handlers/progress.go
+++ b/pkg/handlers/progress.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spider-pigs/spidomtr"
@@ -12,9 +13,11 @@ import (
 const barWidth = 68
 
 type progressBar struct {
-	count   int
-	current int
-	start   time.Time
+	mu       sync.Mutex
+	count    int
+	current  int
+	start    time.Time
+	lastDraw time.Time
 }
 
 // ProgressBar is a runner handler that displays a running progress
@@ -32,7 +35,17 @@ func (b *progressBar) RunnerStarted(id, description string, count int) {
 
 // TestDone is called when a test has been completed.
 func (b *progressBar) TestDone(spidomtr.TestResult) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.current++
+	if b.current < b.count && time.Since(b.lastDraw) < 200*time.Millisecond {
+		return
+	}
+	b.lastDraw = time.Now()
+	b.draw()
+}
+
+func (b *progressBar) draw() {
 	filled := barWidth * b.current / b.count
 	var bar string
 	if b.current == b.count {
@@ -44,7 +57,7 @@ func (b *progressBar) TestDone(spidomtr.TestResult) {
 	}
 	pct := 100 * b.current / b.count
 	elapsed := time.Since(b.start).Truncate(time.Second)
-	fmt.Fprintf(os.Stderr, "\r[%s] %3d%% %4s", bar, pct, elapsed)
+	fmt.Fprintf(os.Stderr, "\033[2K\r[%s] %3d%% %4s", bar, pct, elapsed)
 }
 
 // RunnerDone is called when the runner has run all tests.


### PR DESCRIPTION
The progress bar and logger handlers both wrote to the terminal during test execution, causing garbled output.

Throttle progress bar redraws to 200ms intervals and add a mutex to prevent concurrent write corruption. Clear the line with an ANSI escape sequence before each redraw.

Buffer all logger output and print it once after the run completes, so it no longer interleaves with the progress bar.